### PR TITLE
Change go.tools import path to golang.org/x/tools

### DIFF
--- a/rewriter.go
+++ b/rewriter.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/go.tools/go/gcimporter"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/gcimporter"
+	"golang.org/x/tools/go/types"
 	"fmt"
 	"go/ast"
 	"go/build"


### PR DESCRIPTION
Hi, When I built with master, an error occurred like below:

```
cannot use gcimporter.Import (type func(map[string]*"golang.org/x/tools/go/types".Package, string) (*"golang.org/x/tools/go/types".Package, error)) as type "code.google.com/p/go.tools/go/types".Importer in assignment
```

The import path of go.tools are changed from `code.google.com/p/go.*` to `golang.org/x/*`. So we have to use new import path.

see:
https://groups.google.com/forum/#!topic/golang-announce/eD8dh3T9yyA
