### PR TITLE
How about make gopwt `go test` able instead of providing gopwt command?

### DIFF
--- a/_example/example_test.go
+++ b/_example/example_test.go
@@ -2,11 +2,21 @@ package main
 
 import (
 	"database/sql"
+	"flag"
 	"fmt"
-	"github.com/ToQoz/gopwt/assert"
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/ToQoz/gopwt"
+	"github.com/ToQoz/gopwt/assert"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	gopwt.Main() // magic happens
+	os.Exit(m.Run())
+}
 
 func TestWithMessage(t *testing.T) {
 	var receiver *struct{}

--- a/astutils.go
+++ b/astutils.go
@@ -1,4 +1,4 @@
-package main
+package gopwt
 
 import (
 	"bytes"
@@ -112,6 +112,32 @@ func getAssertImport(a *ast.File) *ast.ImportSpec {
 			imp := imp.(*ast.ImportSpec)
 
 			if imp.Path.Value == `"github.com/ToQoz/gopwt/assert"` {
+				return imp
+			}
+		}
+	}
+
+	return nil
+}
+
+func getGopwtImport(a *ast.File) *ast.ImportSpec {
+	for _, decl := range a.Decls {
+		decl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		if len(decl.Specs) == 0 {
+			continue
+		}
+
+		if _, ok := decl.Specs[0].(*ast.ImportSpec); !ok {
+			continue
+		}
+
+		for _, imp := range decl.Specs {
+			imp := imp.(*ast.ImportSpec)
+
+			if imp.Path.Value == `"github.com/ToQoz/gopwt"` {
 				return imp
 			}
 		}

--- a/astutils_test.go
+++ b/astutils_test.go
@@ -1,12 +1,13 @@
-package main
+package gopwt
 
 import (
-	"github.com/ToQoz/gopwt/assert"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"strings"
 	"testing"
+
+	"github.com/ToQoz/gopwt/assert"
 )
 
 func TestIsAssert_Regression(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -37,4 +37,4 @@ Usage
 	FAIL    github.com/ToQoz/gopwt/foo      0.006s
 	exit status 1
 */
-package main
+package gopwt

--- a/main.go
+++ b/main.go
@@ -1,16 +1,18 @@
-package main
+package gopwt
 
 import (
 	"flag"
 	"fmt"
-	"github.com/mattn/go-isatty"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/mattn/go-isatty"
 )
 
 var (
@@ -19,7 +21,17 @@ var (
 	testdata = flag.String("testdata", "testdata", "name of test data directories. e.g. -testdata testdata,migrations")
 )
 
-func main() {
+func Main() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	if strings.HasPrefix(dir, os.TempDir()) {
+		// XXX: dirty hack
+		// Return if Main() is called from translated test to avoid recursive call.
+		// I guess re-writing Main() func in tranlation is better.
+		return
+	}
 	if err := doMain(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(2)
@@ -131,16 +143,18 @@ func rewrite(tempGoPath string, pkgInfo *packageInfo) error {
 }
 
 func runTest(goPath string, pkgInfo *packageInfo, stdout, stderr io.Writer) error {
-	err := os.Setenv("GOPATH", goPath+":"+os.Getenv("GOPATH"))
-	if err != nil {
-		return err
-	}
+	// err := os.Setenv("GOPATH", os.Getenv("GOPATH"))
+	// if err != nil {
+	// 	return err
+	// }
 
 	cmd := exec.Command("go", "test")
 	if *verbose {
 		cmd.Args = append(cmd.Args, "-v")
 	}
-	cmd.Args = append(cmd.Args, pkgInfo.ToGoTestArg())
+	cmd.Dir = path.Join(goPath, "src", pkgInfo.importPath)
+	// cmd.Args = append(cmd.Args, pkgInfo.ToGoTestArg())
+	cmd.Args = append(cmd.Args, ".")
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	return cmd.Run()

--- a/main.go
+++ b/main.go
@@ -154,7 +154,6 @@ func runTest(goPath string, pkgInfo *packageInfo, stdout, stderr io.Writer) erro
 	}
 	cmd.Dir = path.Join(goPath, "src", pkgInfo.importPath)
 	// cmd.Args = append(cmd.Args, pkgInfo.ToGoTestArg())
-	cmd.Args = append(cmd.Args, ".")
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	return cmd.Run()

--- a/packageinfo.go
+++ b/packageinfo.go
@@ -1,4 +1,4 @@
-package main
+package gopwt
 
 import (
 	"fmt"

--- a/packageinfo_test.go
+++ b/packageinfo_test.go
@@ -1,9 +1,10 @@
-package main
+package gopwt
 
 import (
-	"github.com/ToQoz/gopwt/assert"
 	"reflect"
 	"testing"
+
+	"github.com/ToQoz/gopwt/assert"
 )
 
 func TestNewPackageInfo(t *testing.T) {

--- a/rewriter.go
+++ b/rewriter.go
@@ -80,29 +80,6 @@ func rewritePackage(pkgDir, importPath string, tempGoSrcDir string) error {
 			continue
 		}
 
-		// gopwtImport := getGopwtImport(f)
-		// if gopwtImport != nil {
-		// 	fmt.Println(gopwtImport.Path.Value)
-		// 	gopwtImport.Path.Value = ""
-		// }
-		//
-		// ast.Inspect(f, func(n ast.Node) bool {
-		// 	switch n.(type) {
-		// 	case *ast.CallExpr:
-		// 		n := n.(*ast.CallExpr)
-		//
-		// 		if _, ok := n.Fun.(*ast.FuncLit); ok {
-		// 			return true
-		// 		}
-		//
-		// 		n.Fun
-		//
-		// 		// fn(n)
-		// 		return false
-		// 	}
-		// 	return false
-		// })
-
 		assertImportIdent = &ast.Ident{Name: "assert"}
 		assertImport := getAssertImport(f)
 		if assertImport == nil {

--- a/rewriter.go
+++ b/rewriter.go
@@ -6,7 +6,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
-	"golang.org/x/tools/go/types"
+	"go/types"
 	"io"
 	"io/ioutil"
 	"os"

--- a/rewriter.go
+++ b/rewriter.go
@@ -1,4 +1,4 @@
-package main
+package gopwt
 
 import (
 	"bytes"
@@ -79,6 +79,29 @@ func rewritePackage(pkgDir, importPath string, tempGoSrcDir string) error {
 		if !isTestGoFileName(path) {
 			continue
 		}
+
+		// gopwtImport := getGopwtImport(f)
+		// if gopwtImport != nil {
+		// 	fmt.Println(gopwtImport.Path.Value)
+		// 	gopwtImport.Path.Value = ""
+		// }
+		//
+		// ast.Inspect(f, func(n ast.Node) bool {
+		// 	switch n.(type) {
+		// 	case *ast.CallExpr:
+		// 		n := n.(*ast.CallExpr)
+		//
+		// 		if _, ok := n.Fun.(*ast.FuncLit); ok {
+		// 			return true
+		// 		}
+		//
+		// 		n.Fun
+		//
+		// 		// fn(n)
+		// 		return false
+		// 	}
+		// 	return false
+		// })
 
 		assertImportIdent = &ast.Ident{Name: "assert"}
 		assertImport := getAssertImport(f)

--- a/rewriter_test.go
+++ b/rewriter_test.go
@@ -1,14 +1,15 @@
-package main
+package gopwt
 
 import (
 	"bytes"
-	"github.com/ToQoz/gopwt/assert"
 	"go/ast"
 	"go/parser"
 	"go/printer"
 	"go/token"
 	"io/ioutil"
 	"testing"
+
+	"github.com/ToQoz/gopwt/assert"
 )
 
 func TestDontPanic_OnTypeConversion(t *testing.T) {

--- a/translatedassert/assert.go
+++ b/translatedassert/assert.go
@@ -3,12 +3,13 @@ package translatedassert
 
 import (
 	"fmt"
-	"github.com/k0kubun/pp"
-	"github.com/mattn/go-runewidth"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/k0kubun/pp"
+	"github.com/mattn/go-runewidth"
 )
 
 var cachedFuncRet = map[string]map[int]interface{}{}

--- a/types.go
+++ b/types.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"go/ast"
+	"go/importer"
+	// "go/internal/gcimporter"
 	"go/token"
-	"golang.org/x/tools/go/gcimporter"
-	"golang.org/x/tools/go/types"
+	"go/types"
 	"os"
 	"os/exec"
 )
@@ -61,7 +62,8 @@ func getTypeInfo(pkgDir, importPath, tempGoSrcDir string, fset *token.FileSet, f
 	}
 
 	// Assume types from ast.Node
-	typesConfig.Import = gcimporter.Import
+	// typesConfig.Import = gcimporter.Import
+	typesConfig.Importer = importer.Default()
 	pkg := types.NewPackage(importPath, "")
 	info := &types.Info{
 		Types:      map[ast.Expr]types.TypeAndValue{},

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package main
+package gopwt
 
 import (
 	"go/ast"

--- a/types_test.go
+++ b/types_test.go
@@ -1,7 +1,6 @@
-package main
+package gopwt
 
 import (
-	"github.com/ToQoz/gopwt/assert"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -9,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/ToQoz/gopwt/assert"
 )
 
 func TestDeterminantExprOfIsTypeConversion(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -1,4 +1,4 @@
-package main
+package gopwt
 
 import (
 	"go/token"

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,14 +1,15 @@
-package main
+package gopwt
 
 import (
 	"fmt"
-	"github.com/ToQoz/gopwt/assert"
 	"go/parser"
 	"go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ToQoz/gopwt/assert"
 )
 
 func TestMust(t *testing.T) {


### PR DESCRIPTION
```go
func TestMain(m *testing.M) {
	flag.Parse()
	gopwt.Main() // magic happens
	os.Exit(m.Run())
}
```

By using TestMain, we can run tests with gopwt by `go test`.

I think it's more prefarable and it's easy to reach out gopwt.

I opened pull-request, but it's just a proof of concept.
You don't have to merge this. I just want to discuss it with a working code.
Please feel free to close it.

It introduces some problems like output duplicated exit status message and color output doesn't work.

However, i guess the core feature of gopwt works as expected.

What do you think?
