### PR TITLE
fix(gopwt/translatedassert): prevent panic on Bcomplex(1, 2)

### DIFF
--- a/translatedassert/builtin.go
+++ b/translatedassert/builtin.go
@@ -46,6 +46,11 @@ func Bcomplex(r, i interface{}) (c interface{}) {
 	case float64:
 		c = complex(r.(float64), i.(float64))
 		return
+	case int:
+		fr := float64(r.(int))
+		fi := float64(i.(int))
+		c = complex(fr, fi)
+		return
 	}
 
 	panic("complex can take floats")

--- a/translatedassert/builtin_test.go
+++ b/translatedassert/builtin_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestBcomplex(t *testing.T) {
+	if complex(1, 2) != Bcomplex(1, 2) {
+		t.Errorf("Bcomplex behavior should be equal to complex")
+	}
+
+	if complex(1.0, 2.2) != Bcomplex(1.0, 2.2) {
+		t.Errorf("Bcomplex behavior should be equal to complex, %#v %#v", complex(1.0, 2.2), Bcomplex(1.0, 2.2))
+	}
+
+	if complex(float64(1.0), float64(2.2)) != Bcomplex(float64(1.0), float64(2.2)) {
+		t.Errorf("Bcomplex behavior should be equal to complex, %#v %#v", complex(1.0, 2.2), Bcomplex(1.0, 2.2))
+	}
+
+	if complex(float32(1.0), float32(2.2)) != Bcomplex(float32(1.0), float32(2.2)).(complex64) {
+		t.Errorf("Bcomplex behavior should be equal to complex, %#v %#v", complex(1.0, 2.2), Bcomplex(1.0, 2.2))
+	}
+}
+
 func TestBnew(t *testing.T) {
 	var expected interface{}
 	var got interface{}


### PR DESCRIPTION
fix panic on on `Bcomplex(1, 2)`.

```
--- FAIL: TestBcomplex (0.00s)
panic: complex can take floats [recovered]
        panic: complex can take floats
```