### PR TITLE
Support default GOPATH (Go 1.8+)

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,9 +69,11 @@ func doMain() error {
 }
 
 func runTest(gopath string, importpath string, stdout, stderr io.Writer) error {
-	err := os.Setenv("GOPATH", gopath+":"+os.Getenv("GOPATH"))
-	if err != nil {
-		return err
+	if os.Getenv("GOPATH") != "" {
+		err := os.Setenv("GOPATH", gopath+":"+os.Getenv("GOPATH"))
+		if err != nil {
+			return err
+		}
 	}
 	cmd := exec.Command("go", "test")
 


### PR DESCRIPTION
From Go 1.8, it uses $HOME/go as default GOPATH. But if it is not specified, gopwt would abort.

```
go: GOPATH entry is relative; must be absolute path: "".
For more details see: 'go help gopath'
exit status 2
```