### PR TITLE
chore(gopwt/translator): make errros on `go install` understandable.

### DIFF
--- a/translator/internal/types.go
+++ b/translator/internal/types.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"bytes"
+	"fmt"
 	"go/ast"
 	"go/importer"
 	// "go/internal/gcimporter"
@@ -52,13 +54,15 @@ func GetTypeInfo(pkgDir, importPath, tempGoSrcDir string, fset *token.FileSet, f
 		install := exec.Command("go", "install")
 		install.Dir = pkgDir
 		install.Stdout = os.Stdout
-		install.Stderr = os.Stderr
+		b := []byte{}
+		buf := bytes.NewBuffer(b)
+		install.Stderr = buf
 		if Verbose {
 			install.Args = append(install.Args, "-v")
 		}
 		install.Args = append(install.Args, deps...)
 		if err := install.Run(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("[ERROR] go install %s\n\n%s", strings.Join(deps, " "), buf.String())
 		}
 	}
 


### PR DESCRIPTION
before:

```
can't load package: package github.com/leanovate/gopter: cannot find package "github.com/leanovate/gopter" in any of:
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/leanovate/gopter (from $GOROOT)
        /Users/t_matsumoto/_go/src/github.com/leanovate/gopter (from $GOPATH)
can't load package: package github.com/leanovate/gopter/gen: cannot find package "github.com/leanovate/gopter/gen" in any of:
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/leanovate/gopter/gen (from $GOROOT)
        /Users/t_matsumoto/_go/src/github.com/leanovate/gopter/gen (from $GOPATH)
can't load package: package github.com/leanovate/gopter/prop: cannot find package "github.com/leanovate/gopter/prop" in any of:
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/leanovate/gopter/prop (from $GOROOT)
        /Users/t_matsumoto/_go/src/github.com/leanovate/gopter/prop (from $GOPATH)
exit status 1
exit status 1
FAIL    github.com/a/b       0.424s
```

after:

```
[ERROR] go install bufio bytes crypto/sha256 flag fmt github.com/pkg/errors go.uber.org/zap io io/ioutil os path/filepath regexp strings github.com/ToQoz/gopwt github.com/ToQoz/gopwt/assert github.com/leanovate/gopter github.com/leanovate/gopter/gen github.com/leanovate/gopter/prop reflect sort testing .

can't load package: package github.com/leanovate/gopter: cannot find package "github.com/leanovate/gopter" in any of:
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/leanovate/gopter (from $GOROOT)
        /Users/t_matsumoto/_go/src/github.com/leanovate/gopter (from $GOPATH)
can't load package: package github.com/leanovate/gopter/gen: cannot find package "github.com/leanovate/gopter/gen" in any of:
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/leanovate/gopter/gen (from $GOROOT)
        /Users/t_matsumoto/_go/src/github.com/leanovate/gopter/gen (from $GOPATH)
can't load package: package github.com/leanovate/gopter/prop: cannot find package "github.com/leanovate/gopter/prop" in any of:
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/leanovate/gopter/prop (from $GOROOT)
        /Users/t_matsumoto/_go/src/github.com/leanovate/gopter/prop (from $GOPATH)

exit status 127
FAIL    github.com/a/b       0.409s
```